### PR TITLE
Update to Okendo Shopify Hydrogen 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@headlessui/react": "^1.6.4",
         "@heroicons/react": "^1.0.6",
-        "@okendo/shopify-hydrogen": "^1.2.1",
+        "@okendo/shopify-hydrogen": "^1.2.2",
         "@shopify/hydrogen": "^1.2.0",
         "clsx": "^1.1.1",
         "graphql-tag": "^2.12.6",
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/@okendo/shopify-hydrogen": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-1.2.1.tgz",
-      "integrity": "sha512-6ocKuYl38zz0hv8umOWM2vUGAVSdEp9+LglsBlDqhugIKpnhoWFa4kMGczfLcCdYWCM+l+MeooAQh0LBzTKY9w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-1.2.2.tgz",
+      "integrity": "sha512-HC81YdlGjwyBTRzp+FBR1g9VzNu/QhZlNn1MGLp/OMUvsldcq6cp3jgchVAxrL1wFYxSP79Q8HIxzShpbL2+KA==",
       "engines": {
         "node": ">=14"
       },
@@ -10104,9 +10104,9 @@
       "dev": true
     },
     "@okendo/shopify-hydrogen": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-1.2.1.tgz",
-      "integrity": "sha512-6ocKuYl38zz0hv8umOWM2vUGAVSdEp9+LglsBlDqhugIKpnhoWFa4kMGczfLcCdYWCM+l+MeooAQh0LBzTKY9w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-1.2.2.tgz",
+      "integrity": "sha512-HC81YdlGjwyBTRzp+FBR1g9VzNu/QhZlNn1MGLp/OMUvsldcq6cp3jgchVAxrL1wFYxSP79Q8HIxzShpbL2+KA==",
       "requires": {}
     },
     "@polka/url": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@headlessui/react": "^1.6.4",
     "@heroicons/react": "^1.0.6",
-    "@okendo/shopify-hydrogen": "^1.2.1",
+    "@okendo/shopify-hydrogen": "^1.2.2",
     "@shopify/hydrogen": "^1.2.0",
     "clsx": "^1.1.1",
     "graphql-tag": "^2.12.6",


### PR DESCRIPTION
* Silence no metafields present warning / all warnings - Particularly seen in Star Rating Snippets
* Watch attribute changes in `useEffect` to better support re-initialisation on route changes