### PR TITLE
Simplify CSP and remove nonce

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,11 +1,11 @@
-import {ServerRouter} from 'react-router';
-import {isbot} from 'isbot';
-import {renderToReadableStream} from 'react-dom/server';
 import {
   createContentSecurityPolicy,
   type HydrogenRouterContextProvider,
 } from '@shopify/hydrogen';
+import {isbot} from 'isbot';
+import {renderToReadableStream} from 'react-dom/server';
 import type {EntryContext} from 'react-router';
+import {ServerRouter} from 'react-router';
 
 export default async function handleRequest(
   request: Request,
@@ -20,9 +20,6 @@ export default async function handleRequest(
       storeDomain: context.env.PUBLIC_STORE_DOMAIN,
     },
     defaultSrc: [
-      "'self'",
-      'localhost:*',
-      'https://cdn.shopify.com',
       'https://www.google.com',
       'https://www.gstatic.com',
       'https://d3hw6dc1ow8pp2.cloudfront.net',
@@ -33,59 +30,14 @@ export default async function handleRequest(
       'https://api.okendo.io',
       'data:',
     ],
-    imgSrc: [
-      "'self'",
-      'https://cdn.shopify.com',
-      'data:',
-      'https://d3hw6dc1ow8pp2.cloudfront.net',
-      'https://d3g5hqndtiniji.cloudfront.net',
-      'https://dov7r31oq5dkj.cloudfront.net',
-      'https://cdn-static.okendo.io',
-      'https://surveys.okendo.io',
-    ],
-    mediaSrc: [
-      "'self'",
-      'https://d3hw6dc1ow8pp2.cloudfront.net',
-      'https://d3g5hqndtiniji.cloudfront.net',
-      'https://dov7r31oq5dkj.cloudfront.net',
-      'https://cdn-static.okendo.io',
-    ],
     styleSrc: [
-      "'self'",
-      "'unsafe-inline'",
-      'https://cdn.shopify.com',
       'https://fonts.googleapis.com',
       'https://fonts.gstatic.com',
       'https://d3hw6dc1ow8pp2.cloudfront.net',
       'https://cdn-static.okendo.io',
       'https://surveys.okendo.io',
     ],
-    scriptSrc: [
-      "'self'",
-      'https://cdn.shopify.com',
-      'https://d3hw6dc1ow8pp2.cloudfront.net',
-      'https://dov7r31oq5dkj.cloudfront.net',
-      'https://cdn-static.okendo.io',
-      'https://surveys.okendo.io',
-      'https://api.okendo.io',
-      'https://www.google.com',
-      'https://www.gstatic.com',
-    ],
-    fontSrc: [
-      "'self'",
-      'https://fonts.gstatic.com',
-      'https://d3hw6dc1ow8pp2.cloudfront.net',
-      'https://dov7r31oq5dkj.cloudfront.net',
-      'https://cdn.shopify.com',
-      'https://cdn-static.okendo.io',
-      'https://surveys.okendo.io',
-    ],
     connectSrc: [
-      "'self'",
-      'https://monorail-edge.shopifysvc.com',
-      'localhost:*',
-      'ws://localhost:*',
-      'ws://127.0.0.1:*',
       'https://api.okendo.io',
       'https://cdn-static.okendo.io',
       'https://surveys.okendo.io',

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -173,14 +173,13 @@ export function Layout({children}: {children?: React.ReactNode}) {
 
 export default function App() {
   const data = useRouteLoaderData<RootLoader>('root');
-  const nonce = useNonce();
 
   if (!data) {
     return <Outlet />;
   }
 
   return (
-    <OkendoProvider nonce={nonce} okendoProviderData={data.okendoProviderData}>
+    <OkendoProvider okendoProviderData={data.okendoProviderData}>
       <Analytics.Provider
         cart={data.cart}
         shop={data.shop}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "okendo-shopify-hydrogen-demo",
       "version": "2025.7.0",
       "dependencies": {
-        "@okendo/shopify-hydrogen": "^2.5.3",
+        "@okendo/shopify-hydrogen": "^2.6.0",
         "@shopify/hydrogen": "2025.7.0",
         "graphql": "^16.10.0",
         "graphql-tag": "^2.12.6",
@@ -2959,9 +2959,9 @@
       }
     },
     "node_modules/@okendo/shopify-hydrogen": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-2.5.3.tgz",
-      "integrity": "sha512-02ZR+Di46j+jKMxViD7/FvI3BReX1/otXgXTdPp7O8hXx4lqXn4CihEh2ho6us8X6T9oFOV/dQZWVba/XKuxUw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@okendo/shopify-hydrogen/-/shopify-hydrogen-2.6.0.tgz",
+      "integrity": "sha512-VV77FFjkl8B7M0Gi1gTwBg/SDFXQaUXYz4mvpb5xyhO6llQXV/vBrYLqBG3NoX40aslG+rGL/njsBnHuJUt8Ug==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "prettier": "@shopify/prettier-config",
   "dependencies": {
-    "@okendo/shopify-hydrogen": "^2.5.3",
+    "@okendo/shopify-hydrogen": "^2.6.0",
     "@shopify/hydrogen": "2025.7.0",
     "graphql": "^16.10.0",
     "graphql-tag": "^2.12.6",

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -346,6 +346,9 @@ export type RecommendedProductFragment = Pick<
   featuredImage?: StorefrontAPI.Maybe<
     Pick<StorefrontAPI.Image, 'id' | 'url' | 'altText' | 'width' | 'height'>
   >;
+  okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+    Pick<StorefrontAPI.Metafield, 'value'>
+  >;
 };
 
 export type RecommendedProductsQueryVariables = StorefrontAPI.Exact<{
@@ -368,6 +371,9 @@ export type RecommendedProductsQuery = {
             StorefrontAPI.Image,
             'id' | 'url' | 'altText' | 'width' | 'height'
           >
+        >;
+        okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+          Pick<StorefrontAPI.Metafield, 'value'>
         >;
       }
     >;
@@ -509,6 +515,9 @@ export type ProductItemFragment = Pick<
     minVariantPrice: Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>;
     maxVariantPrice: Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>;
   };
+  okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+    Pick<StorefrontAPI.Metafield, 'value'>
+  >;
 };
 
 export type CollectionQueryVariables = StorefrontAPI.Exact<{
@@ -550,6 +559,9 @@ export type CollectionQuery = {
                 'amount' | 'currencyCode'
               >;
             };
+            okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+              Pick<StorefrontAPI.Metafield, 'value'>
+            >;
           }
         >;
         pageInfo: Pick<
@@ -618,6 +630,9 @@ export type CollectionItemFragment = Pick<
     minVariantPrice: Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>;
     maxVariantPrice: Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>;
   };
+  okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+    Pick<StorefrontAPI.Metafield, 'value'>
+  >;
 };
 
 export type CatalogQueryVariables = StorefrontAPI.Exact<{
@@ -653,6 +668,9 @@ export type CatalogQuery = {
             'amount' | 'currencyCode'
           >;
         };
+        okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+          Pick<StorefrontAPI.Metafield, 'value'>
+        >;
       }
     >;
     pageInfo: Pick<
@@ -861,6 +879,12 @@ export type ProductFragment = Pick<
     }
   >;
   seo: Pick<StorefrontAPI.Seo, 'description' | 'title'>;
+  okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+    Pick<StorefrontAPI.Metafield, 'value'>
+  >;
+  okendoReviewsSnippet?: StorefrontAPI.Maybe<
+    Pick<StorefrontAPI.Metafield, 'value'>
+  >;
 };
 
 export type ProductQueryVariables = StorefrontAPI.Exact<{
@@ -975,6 +999,12 @@ export type ProductQuery = {
         }
       >;
       seo: Pick<StorefrontAPI.Seo, 'description' | 'title'>;
+      okendoStarRatingSnippet?: StorefrontAPI.Maybe<
+        Pick<StorefrontAPI.Metafield, 'value'>
+      >;
+      okendoReviewsSnippet?: StorefrontAPI.Maybe<
+        Pick<StorefrontAPI.Metafield, 'value'>
+      >;
     }
   >;
 };
@@ -1214,7 +1244,7 @@ interface GeneratedQueryTypes {
     return: FeaturedCollectionQuery;
     variables: FeaturedCollectionQueryVariables;
   };
-  '#graphql\n  fragment RecommendedProduct on Product {\n    id\n    title\n    handle\n    priceRange {\n      minVariantPrice {\n        amount\n        currencyCode\n      }\n    }\n    featuredImage {\n      id\n      url\n      altText\n      width\n      height\n    }\n  }\n  query RecommendedProducts ($country: CountryCode, $language: LanguageCode)\n    @inContext(country: $country, language: $language) {\n    products(first: 4, sortKey: UPDATED_AT, reverse: true) {\n      nodes {\n        ...RecommendedProduct\n      }\n    }\n  }\n': {
+  '#graphql\n  #graphql\n  fragment OkendoStarRatingSnippet on Product {\n    okendoStarRatingSnippet: metafield(\n      namespace: "app--1576377--reviews"\n      key: "star_rating_snippet"\n    ) {\n      value\n    }\n  }\n\n  fragment RecommendedProduct on Product {\n    id\n    title\n    handle\n    priceRange {\n      minVariantPrice {\n        amount\n        currencyCode\n      }\n    }\n    featuredImage {\n      id\n      url\n      altText\n      width\n      height\n    }\n    ...OkendoStarRatingSnippet\n  }\n  query RecommendedProducts ($country: CountryCode, $language: LanguageCode)\n    @inContext(country: $country, language: $language) {\n    products(first: 4, sortKey: UPDATED_AT, reverse: true) {\n      nodes {\n        ...RecommendedProduct\n      }\n    }\n  }\n': {
     return: RecommendedProductsQuery;
     variables: RecommendedProductsQueryVariables;
   };
@@ -1230,7 +1260,7 @@ interface GeneratedQueryTypes {
     return: BlogsQuery;
     variables: BlogsQueryVariables;
   };
-  '#graphql\n  #graphql\n  fragment MoneyProductItem on MoneyV2 {\n    amount\n    currencyCode\n  }\n  fragment ProductItem on Product {\n    id\n    handle\n    title\n    featuredImage {\n      id\n      altText\n      url\n      width\n      height\n    }\n    priceRange {\n      minVariantPrice {\n        ...MoneyProductItem\n      }\n      maxVariantPrice {\n        ...MoneyProductItem\n      }\n    }\n  }\n\n  query Collection(\n    $handle: String!\n    $country: CountryCode\n    $language: LanguageCode\n    $first: Int\n    $last: Int\n    $startCursor: String\n    $endCursor: String\n  ) @inContext(country: $country, language: $language) {\n    collection(handle: $handle) {\n      id\n      handle\n      title\n      description\n      products(\n        first: $first,\n        last: $last,\n        before: $startCursor,\n        after: $endCursor\n      ) {\n        nodes {\n          ...ProductItem\n        }\n        pageInfo {\n          hasPreviousPage\n          hasNextPage\n          endCursor\n          startCursor\n        }\n      }\n    }\n  }\n': {
+  '#graphql\n  #graphql\n  #graphql\n  fragment OkendoStarRatingSnippet on Product {\n    okendoStarRatingSnippet: metafield(\n      namespace: "app--1576377--reviews"\n      key: "star_rating_snippet"\n    ) {\n      value\n    }\n  }\n\n  fragment MoneyProductItem on MoneyV2 {\n    amount\n    currencyCode\n  }\n  fragment ProductItem on Product {\n    id\n    handle\n    title\n    featuredImage {\n      id\n      altText\n      url\n      width\n      height\n    }\n    priceRange {\n      minVariantPrice {\n        ...MoneyProductItem\n      }\n      maxVariantPrice {\n        ...MoneyProductItem\n      }\n    }\n    ...OkendoStarRatingSnippet\n  }\n\n  query Collection(\n    $handle: String!\n    $country: CountryCode\n    $language: LanguageCode\n    $first: Int\n    $last: Int\n    $startCursor: String\n    $endCursor: String\n  ) @inContext(country: $country, language: $language) {\n    collection(handle: $handle) {\n      id\n      handle\n      title\n      description\n      products(\n        first: $first,\n        last: $last,\n        before: $startCursor,\n        after: $endCursor\n      ) {\n        nodes {\n          ...ProductItem\n        }\n        pageInfo {\n          hasPreviousPage\n          hasNextPage\n          endCursor\n          startCursor\n        }\n      }\n    }\n  }\n': {
     return: CollectionQuery;
     variables: CollectionQueryVariables;
   };
@@ -1238,7 +1268,7 @@ interface GeneratedQueryTypes {
     return: StoreCollectionsQuery;
     variables: StoreCollectionsQueryVariables;
   };
-  '#graphql\n  query Catalog(\n    $country: CountryCode\n    $language: LanguageCode\n    $first: Int\n    $last: Int\n    $startCursor: String\n    $endCursor: String\n  ) @inContext(country: $country, language: $language) {\n    products(first: $first, last: $last, before: $startCursor, after: $endCursor) {\n      nodes {\n        ...CollectionItem\n      }\n      pageInfo {\n        hasPreviousPage\n        hasNextPage\n        startCursor\n        endCursor\n      }\n    }\n  }\n  #graphql\n  fragment MoneyCollectionItem on MoneyV2 {\n    amount\n    currencyCode\n  }\n  fragment CollectionItem on Product {\n    id\n    handle\n    title\n    featuredImage {\n      id\n      altText\n      url\n      width\n      height\n    }\n    priceRange {\n      minVariantPrice {\n        ...MoneyCollectionItem\n      }\n      maxVariantPrice {\n        ...MoneyCollectionItem\n      }\n    }\n  }\n\n': {
+  '#graphql\n  query Catalog(\n    $country: CountryCode\n    $language: LanguageCode\n    $first: Int\n    $last: Int\n    $startCursor: String\n    $endCursor: String\n  ) @inContext(country: $country, language: $language) {\n    products(first: $first, last: $last, before: $startCursor, after: $endCursor) {\n      nodes {\n        ...CollectionItem\n      }\n      pageInfo {\n        hasPreviousPage\n        hasNextPage\n        startCursor\n        endCursor\n      }\n    }\n  }\n  #graphql\n  #graphql\n  fragment OkendoStarRatingSnippet on Product {\n    okendoStarRatingSnippet: metafield(\n      namespace: "app--1576377--reviews"\n      key: "star_rating_snippet"\n    ) {\n      value\n    }\n  }\n\n  fragment MoneyCollectionItem on MoneyV2 {\n    amount\n    currencyCode\n  }\n  fragment CollectionItem on Product {\n    id\n    handle\n    title\n    featuredImage {\n      id\n      altText\n      url\n      width\n      height\n    }\n    priceRange {\n      minVariantPrice {\n        ...MoneyCollectionItem\n      }\n      maxVariantPrice {\n        ...MoneyCollectionItem\n      }\n    }\n    ...OkendoStarRatingSnippet\n  }\n\n': {
     return: CatalogQuery;
     variables: CatalogQueryVariables;
   };
@@ -1254,7 +1284,7 @@ interface GeneratedQueryTypes {
     return: PoliciesQuery;
     variables: PoliciesQueryVariables;
   };
-  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    encodedVariantExistence\n    encodedVariantAvailability\n    options {\n      name\n      optionValues {\n        name\n        firstSelectableVariant {\n          ...ProductVariant\n        }\n        swatch {\n          color\n          image {\n            previewImage {\n              url\n            }\n          }\n        }\n      }\n    }\n    selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {\n      ...ProductVariant\n    }\n    adjacentVariants (selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    seo {\n      description\n      title\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n  }\n\n\n': {
+  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  #graphql\n  fragment OkendoStarRatingSnippet on Product {\n    okendoStarRatingSnippet: metafield(\n      namespace: "app--1576377--reviews"\n      key: "star_rating_snippet"\n    ) {\n      value\n    }\n  }\n\n  #graphql\n  fragment OkendoReviewsSnippet on Product {\n    okendoReviewsSnippet: metafield(\n      namespace: "app--1576377--reviews"\n      key: "reviews_widget_snippet"\n    ) {\n      value\n    }\n  }\n\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    encodedVariantExistence\n    encodedVariantAvailability\n    options {\n      name\n      optionValues {\n        name\n        firstSelectableVariant {\n          ...ProductVariant\n        }\n        swatch {\n          color\n          image {\n            previewImage {\n              url\n            }\n          }\n        }\n      }\n    }\n    selectedOrFirstAvailableVariant(selectedOptions: $selectedOptions, ignoreUnknownOptions: true, caseInsensitiveMatch: true) {\n      ...ProductVariant\n    }\n    adjacentVariants (selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    seo {\n      description\n      title\n    }\n    ...OkendoStarRatingSnippet\n    ...OkendoReviewsSnippet\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n  }\n\n\n': {
     return: ProductQuery;
     variables: ProductQueryVariables;
   };


### PR DESCRIPTION
Hydrogen now makes the custom CSP to extend the default one: https://github.com/Shopify/hydrogen/commit/a69c21caa15dfedb88afd50f262f17bf86f74836 So we don't need to repeat the default values anymore. Also, everything in `imgSrc`, `mediaSrc`, `scriptSrc`, and `fontSrc` is also in `defaultSrc`, so we can remove them.

Also, Hydrogen now provides a `Script` component which takes care of passing the nonce. `OkendoProvider` now makes use of this component, so doesn't required to be passed the nonce anymore. Note that `OkendoProvider` also creates `style` tags, but the default values of Hydrogen's CSP for `styleSrc` contains `unsafe-inline`, and this default value is always present (see above), so `style` tags also don't require the nonce anymore.
